### PR TITLE
Change underscore with camelCase in getUser output

### DIFF
--- a/apidocs.source/users/get_users.js
+++ b/apidocs.source/users/get_users.js
@@ -44,8 +44,8 @@
  *           "id": "2",
  *           "type": "user",
  *           "attributes": {
- *             "first_name": "Ellie",
- *             "last_name": "Fredricksen",
+ *             "firstName": "Ellie",
+ *             "lastName": "Fredricksen",
  *             "birthday": "1990-12-03T00:00Z"
  *           }
  *         },
@@ -54,8 +54,8 @@
  *           "type": "user",
  *           "attributes": {
  *             "email": "jack@example.com",
- *             "first_name": "Jack",
- *             "last_name": "Sparrow",
+ *             "firstName": "Jack",
+ *             "lastName": "Sparrow",
  *             "birthday": "1987-10-12T00:00Z"
  *           }
  *         }


### PR DESCRIPTION
Hi there,

I've fixed a little convention issue within /apidocs.source/users/get_user.js:

Old:

```
 *       "data": [
 *         {
 *           "id": "2",
 *           "type": "user",
 *           "attributes": {
 *             "first_name": "Ellie",
 *             "last_name": "Fredricksen",
 *             "birthday": "1990-12-03T00:00Z"
 *           }
 *         },
 *         {
 *           "id": "1",
 *           "type": "user",
 *           "attributes": {
 *             "email": "jack@example.com",
 *             "first_name": "Jack",
 *             "last_name": "Sparrow",
 *             "birthday": "1987-10-12T00:00Z"
 *           }
 *         }
 *       ],
```

New:

```
 *       "data": [
 *         {
 *           "id": "2",
 *           "type": "user",
 *           "attributes": {
 *             "firstName": "Ellie",
 *             "lastName": "Fredricksen",
 *             "birthday": "1990-12-03T00:00Z"
 *           }
 *         },
 *         {
 *           "id": "1",
 *           "type": "user",
 *           "attributes": {
 *             "email": "jack@example.com",
 *             "firstName": "Jack",
 *             "lastName": "Sparrow",
 *             "birthday": "1987-10-12T00:00Z"
 *           }
 *         }
 *       ],
```

Please review and merge.

Thanks.
